### PR TITLE
Added creation of /mnt/spn_shm directory to build script

### DIFF
--- a/dev_build.sh
+++ b/dev_build.sh
@@ -28,3 +28,9 @@ pip install -r requirements.txt
 ./manage.py migrate
 deactivate
 popd
+
+header Creating shared memory directory
+if [ ! -d /mnt/spn_shm ]; then
+    mkdir /mnt/spn_shm
+    chmod 777 /mnt/spn_shm
+fi


### PR DESCRIPTION
...otherwise the bot gets an error message "mkdir(): permission denied".

Not sure about the permissions though. On my workstation, root:docker works fine; but on my laptop I had to chmod 777 despite my user is member in the docker group too.

Also, not sure if I shall prepend a "sudo" before mkdir. Not everyone has sudo installed; but as far as I know, creating a directory in /mnt requires root.