### PR TITLE
fix install_deps_debian.sh

### DIFF
--- a/install_deps_debian.sh
+++ b/install_deps_debian.sh
@@ -8,9 +8,11 @@ apt install \
 	zlib1g-dev \
 	libpython3-dev \
 	libjpeg-dev \
-	docker \
+	docker.io \
 	cmake \
 	libssl-dev \
 	python3-venv \
 	libmariadbclient-dev \
-	libmariadb-dev-compat
+	libmariadb-dev-compat \
+	tmux \
+	doxygen


### PR DESCRIPTION
- tmux und doxygen werden benötigt
- "docker" ist in Debian eine Windowmaker dock app, das richtigige Paket heißt docker.io