### PR TITLE
Fix 502 errors when Nginx is running before SPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ don’t exist yet):
 
 ```python
 DEBUG = False
-ALLOWED_HOSTS = ['localhost', 'your.domain.here']
+ALLOWED_HOSTS = ['127.0.0.1', 'your.domain.here']
 SECRET_KEY = 'make_sure_you_do_not_use_the_one_in_the_template!'
 STATIC_ROOT = '/var/www/spn/staticfiles'
 ```

--- a/helper_scripts/nginx.conf
+++ b/helper_scripts/nginx.conf
@@ -5,8 +5,7 @@ server {
   server_name localhost;
 
   location / {
-    resolver localhost ipv6=off;   # fix error 502 after reboot
-    proxy_pass http://localhost:8000;
+    proxy_pass http://127.0.0.1:8000;
   }
 
   location /websocket {

--- a/helper_scripts/nginx.conf
+++ b/helper_scripts/nginx.conf
@@ -1,3 +1,5 @@
+resolver localhost ipv6=off;
+
 server {
   # Schlangenprogrammiernacht will be reachable under localhost:3000
   # Adjust to your needs

--- a/helper_scripts/nginx.conf
+++ b/helper_scripts/nginx.conf
@@ -1,5 +1,3 @@
-resolver localhost ipv6=off;
-
 server {
   # Schlangenprogrammiernacht will be reachable under localhost:3000
   # Adjust to your needs
@@ -7,11 +5,12 @@ server {
   server_name localhost;
 
   location / {
+    resolver localhost ipv6=off;   # fix error 502 after reboot
     proxy_pass http://localhost:8000;
   }
 
   location /websocket {
-    proxy_pass http://localhost:9009;
+    proxy_pass http://127.0.0.1:9009;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Fixes 502 errors when Nginx is running before SPN

If Nginx can't resolve an upstream server, it stops trying to resolve it via IPv4 very quickly and continues using only IPv6.
As the website is only available with IPv4 on port 8000, this fails.