### PR TITLE
Added Volume to Reverse Proxy Container

### DIFF
--- a/helper_scripts/run_reverseproxy.sh
+++ b/helper_scripts/run_reverseproxy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Reverse proxy for the /websocket
-docker run -it --rm --net host -v `pwd`/helper_scripts/nginx.conf:/etc/nginx/conf.d/default.conf nginx:1-alpine
+docker run -it --rm --net host -v `pwd`/helper_scripts/nginx.conf:/etc/nginx/conf.d/default.conf -v /var/www/spn/staticfiles/:/var/www/spn/staticfiles/ nginx:1-alpine


### PR DESCRIPTION
If you access the website the reverse proxy (in a docker) tries to load /var/www/spn/staticfiles/, but it only exists in the main os and not the docker, so it can't be found. Hiere I just added the Volume, when the docker image gets run